### PR TITLE
ADD: proper padding and spacing for the Footer

### DIFF
--- a/templates/footer.php
+++ b/templates/footer.php
@@ -1,13 +1,13 @@
 <?php declare(strict_types=1);
 ?>
 <div class="bg-orange-500 text-white text-sm">
-    <footer class="mx-auto md:max-w-6xl py-16">
-        <p class="pt-4">Mage OS Nederland - Vereniging - KvK 88186288 - <a
+    <footer class="mx-auto md:max-w-6xl py-8 px-4 md:py-16 space-y-4">
+        <p>Mage OS Nederland - Vereniging - KvK 88186288 - <a
                 href="https://github.com/yireo/mage-os.nl">GitHub source</a></p>
-        <p class="pt-4">Zie je een foutje? Stuur een mail naar <a
+        <p>Zie je een foutje? Stuur een mail naar <a
                 href="mailto:bestuur@nl.mage-os.org">bestuur@nl.mage-os.org</a> of maak een Pull Request aan op onze <a
                 href="https://github.com/yireo/mage-os.nl">GitHub repository</a></p>
-        <p class="pt-4">Magento™ is a registered trademark of Adobe Inc. Mage-OS is not
+        <p>Magento™ is a registered trademark of Adobe Inc. Mage-OS is not
             affiliated with Adobe or Magento Open Source in any way.</p>
     </footer>
 </div>


### PR DESCRIPTION
This fixes the missing padding for the vertical sides and makes sure the spacing for mobile uses a more even sizing for constancy. 

**Result:**

| Now | This MR |
| - | - |
| ![nl mage-os org_(Moto G Power)](https://github.com/mage-os-nl/mage-os.nl/assets/4387541/42672047-8246-41cb-a711-30edda2650a8) |  ![nl mage-os org_(Moto G Power) (1)](https://github.com/mage-os-nl/mage-os.nl/assets/4387541/a16a450d-b716-4c22-8dbe-5aae8748d04c) |

Closes #20 
